### PR TITLE
Added user-defined directory functionality

### DIFF
--- a/Batch CIA 3DS Decryptor.bat
+++ b/Batch CIA 3DS Decryptor.bat
@@ -1,9 +1,46 @@
 @echo off
-mode con cols=52 lines=26
+
+REM Edited by Excallypurr
+REM Last Edit: 11-12-20 2:25AM
+
+mode con cols=100 lines=26
 title Batch CIA 3DS Decryptor
 SetLocal EnableDelayedExpansion
+set count=0
 echo %date% %time% >log.txt 2>&1
-echo Decrypting...
+:SetEncrypt
+if not exist locations.txt (
+	set "EncryptLocation="
+	set /p EncryptLocation="Where are the .3DS/.cia files located: "
+	if exist "!EncryptLocation!" call :SlashChecker !EncryptLocation! encrypted
+
+	) else ( 
+		call :NotExist Encrypt "!EncryptLocation!"
+	)
+	echo.
+	:SetDecrypt
+	set "DecryptLocation="
+	echo Where do you want the decrypted files to be stored? 
+	set /p DecryptLocation="Leave blank for the same directory as the original files: "
+	if exist "!DecryptLocation!" call :SlashChecker !DecryptLocation! decrypted
+	) 
+	if not exist "!DecryptLocation!" ( 
+		call :NotExist Decrypt "!DecryptLocation!"
+	)
+)
+:ScanLocations
+for /f "tokens=2 delims=;" %%a in (locations.txt) do (
+	if !count!==0 set encrypted=%%a
+	if !count!==1 set decrypted=%%a
+	set /a count=count+1
+)
+cls
+echo Copying files to target directory...
+for %%a in (*.exe) do copy %%a !encrypted!>nul
+echo Successfully copied!
+cls
+echo Decrypting...This process can take a few minutes
+cd !encrypted!
 for %%a in (*.ncch) do del "%%a" >nul
 for %%a in (*.3ds) do (
 	set CUTN=%%~na
@@ -21,7 +58,7 @@ for %%a in (*.3ds) do (
 			if %%f==!CUTN!.UpdateData.ncch set i=7
 			set ARG=!ARG! -i "%%f:!i!:!i!"
 		)
-		makerom -f cci -ignoresign -target p -o "!CUTN!-decrypted.3ds"!ARG! >>log.txt 2>&1
+		makerom -f cci -ignoresign -target p -o "!decrypted!\!CUTN!-decrypted.3ds"!ARG! >>log.txt 2>&1
 	)
 )
 for %%a in (*.cia) do (
@@ -68,10 +105,35 @@ for %%a in (*-decfirst.cia) do (
 )
 for %%a in (*-decfirst.cia) do del "%%a" >nul
 for %%a in (*.ncch) do del "%%a" >nul
+for %%a in (*.exe) do del %%a
 cls
 echo Finished, please press any key to exit.
 pause >nul
 exit
+
+:NotExist
+echo "this is var 1" %1
+echo "this is var 2" %2
+if %1==Decrypt if %2=="" (
+	echo decrytped=;!EncryptLocation!;>>locations.txt
+	goto :ScanLocations
+)
+echo Directory does not exist, please enter a valid directory!
+timeout >nul 1
+cls
+goto :Set%1
+
+:SlashChecker
+set PassThrough=%1
+set SlashCheck=!PassThrough:~-1!
+if "!SlashCheck!"=="/" goto :SlashTrue
+if "!SlashCheck!"=="\" goto :SlashTrue
+echo %2=;%1;>>locations.txt
+goto :eof
+:SlashTrue
+set PassThrough=!PassThrough:~0,-1!
+echo %2=;!PassThrough!;>>locations.txt
+goto :eof
 
 :EXF
 if !X! geq !i! (
@@ -91,4 +153,5 @@ exit/B
 set /a dec=0x%~1
 if [%~2] neq [] set %~2=%dec%
 exit/b
+
 rem matif


### PR DESCRIPTION
I know this is a 2-year-old script but I found it and thought it could do a little bit more so I added the ability to set the location for not only where the CIA/3DS files are but the place where the decrypted file is placed. I did this by making the script copy over all the necessary exes and change the working directory to the user set one. The user set preferences are saved in "locations.txt" so that subsequent runs don't require the user's input and remember where the user stored their files. I added that, during the deletion of the ncch and decfirst files, it also deletes the exes so there is nothing left besides the log and the decrypted file. Everything is still left intact in the script's home directory. The other changes are related, like that there is a check to make sure the file path actually exists as well as checking for it to be in the right syntax. Honestly, this works for my specific situation since I store this script separate from my 3ds/cia files so it might not be useful to anyone else but I figured I'd put my changes up just in case. I have more ideas on stuff I could add but I feel like that would just be for my own use and my need to overcomplicate things that don't need to be. Also I am so sorry for doing this at 2AM.